### PR TITLE
Save filter property as XML element instead of a String (#75)

### DIFF
--- a/harvesters/harvester-common/pom.xml
+++ b/harvesters/harvester-common/pom.xml
@@ -62,6 +62,18 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.persistence</groupId>
+      <artifactId>eclipselink</artifactId>
+      <version>2.6.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/harvesters/harvester-common/src/main/java/org/daobs/harvester/config/FilterHandler.java
+++ b/harvesters/harvester-common/src/main/java/org/daobs/harvester/config/FilterHandler.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2014-2016 European Environment Agency
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon
+ * they will be approved by the European Commission -
+ * subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance
+ * with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/community/eupl/og_page/eupl
+ *
+ * Unless required by applicable law or agreed to in
+ * writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+package org.daobs.harvester.config;
+
+import org.apache.commons.lang.StringUtils;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+
+import javax.xml.bind.ValidationEvent;
+import javax.xml.bind.ValidationEventHandler;
+import javax.xml.bind.annotation.DomHandler;
+import javax.xml.bind.helpers.ValidationEventImpl;
+import javax.xml.bind.helpers.ValidationEventLocatorImpl;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+/**
+ * Created by juanl on 22/03/2017.
+ */
+public class FilterHandler implements DomHandler<String, StreamResult> {
+
+  private static final String FILTER_START_TAG =
+    "<daobs:filter xmlns:daobs=\"http://daobs.org\">";
+  private static final String FILTER_END_TAG = "</daobs:filter>";
+
+
+  /**
+   * When a JAXB provider needs to unmarshal a part of a document into an
+   * infoset representation, it first calls this method to create a
+   * {@link Result} object.
+   *
+   * <p>
+   * A JAXB provider will then send a portion of the XML
+   * into the given result. Such a portion always form a subtree
+   * of the whole XML document rooted at an element.
+   *
+   * @param errorHandler if any error happens between the invocation of this method
+   *                     and the invocation of {@link #getElement(Result)}, they
+   *                     must be reported to this handler.
+   *
+   *                     The caller must provide a non-null error handler.
+   *
+   *                     The {@link Result} object created from this method
+   *                     may hold a reference to this error handler.
+   * @return null if the operation fails. The error must have been reported
+   * to the error handler.
+   */
+  @Override
+  public StreamResult createUnmarshaller(ValidationEventHandler errorHandler) {
+    StringWriter xmlWriter = new StringWriter();
+    return new StreamResult(xmlWriter);
+  }
+
+  /**
+   * Once the portion is sent to the {@link Result}. This method is called
+   * by a JAXB provider to obtain the unmarshalled element representation.
+   *
+   * <p>
+   * Multiple invocations of this method may return different objects.
+   * This method can be invoked only when the whole sub-tree are fed
+   * to the {@link Result} object.
+   *
+   * @param rt The {@link Result} object created by {@link #createUnmarshaller(ValidationEventHandler)}.
+   * @return null if the operation fails. The error must have been reported
+   * to the error handler.
+   */
+  @Override
+  public String getElement(StreamResult rt) {
+    String xml = rt.getWriter().toString();
+    if (StringUtils.isEmpty(xml)) {
+      return "";
+    }
+
+    try {
+      return parseAndFormatXmlString(xml, true);
+    } catch (ParserConfigurationException e) {
+      e.printStackTrace();
+    } catch (SAXException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    } catch (TransformerConfigurationException e) {
+      e.printStackTrace();
+    } catch (TransformerException e) {
+      e.printStackTrace();
+    }
+    return "";
+  }
+
+  private String parseAndFormatXmlString(String xml, boolean checkDaobsFilterTag) throws ParserConfigurationException, SAXException, IOException, TransformerException {
+    StringWriter sw = new StringWriter();
+    DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+    Document doc = db.parse(new InputSource(new StringReader(xml)));
+    Transformer t = TransformerFactory.newInstance().newTransformer();
+    t.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+    t.setOutputProperty(OutputKeys.INDENT, "yes");
+
+    Node node = doc.getFirstChild();
+    if (node != null) {
+      if (checkDaobsFilterTag && node.getNodeName().equals("daobs:filter")) {
+        // Skip the <daobs:filter> tag and unmarshall the content
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+          Node child = children.item(i);
+          t.transform(new DOMSource(child), new StreamResult(sw));
+        }
+      } else if (!checkDaobsFilterTag) {
+        // unmarshall the node
+        t.transform(new DOMSource(node), new StreamResult(sw));
+      } else {
+        return "";
+      }
+    }
+    return sw.toString();
+  }
+
+  /**
+   * This method is called when a JAXB provider needs to marshal an element
+   * to XML.
+   *
+   * <p>
+   * If non-null, the returned {@link Source} must contain a whole document
+   * rooted at one element, which will then be weaved into a bigger document
+   * that the JAXB provider is marshalling.
+   *
+   * @param n
+   * @param errorHandler Receives any errors happened during the process of converting
+   *                     an element into a {@link Source}.
+   *
+   *                     The caller must provide a non-null error handler.
+   * @return null if there was an error. The error should have been reported
+   * to the handler.
+   */
+  @Override
+  public Source marshal(String n, ValidationEventHandler errorHandler) {
+    try {
+      String filterContent = parseAndFormatXmlString(n, false);
+
+
+      String xml = FILTER_START_TAG + filterContent.trim() + FILTER_END_TAG;
+      StringReader xmlReader = new StringReader(xml);
+      return new StreamSource(xmlReader);
+    } catch (Exception e) {
+      errorHandler.handleEvent(new ValidationEventImpl(ValidationEvent.WARNING,
+        "filter is not valid XML: " + e.getMessage(),
+        new ValidationEventLocatorImpl(n)));
+      throw new RuntimeException(e);
+    }
+    //return new StreamSource(new StringReader(FILTER_START_TAG + FILTER_END_TAG));
+  }
+}

--- a/harvesters/harvester-common/src/main/java/org/daobs/harvester/config/Harvester.java
+++ b/harvesters/harvester-common/src/main/java/org/daobs/harvester/config/Harvester.java
@@ -23,12 +23,7 @@ package org.daobs.harvester.config;
 
 import java.io.Serializable;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlSchemaType;
-import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
@@ -90,8 +85,9 @@ public class Harvester implements Serializable {
   @XmlElement(namespace = "http://daobs.org", required = true)
   @XmlSchemaType(name = "anyURI")
   protected String url;
-  @XmlElement(namespace = "http://daobs.org")
-  protected Object filter;
+  //@XmlElement(namespace = "http://daobs.org")
+  @XmlAnyElement(value = FilterHandler.class)
+  protected String filter;
   @XmlElement(namespace = "http://daobs.org")
   protected Integer nbOfRecordsPerPage;
   @XmlElement(namespace = "http://daobs.org", required = true)
@@ -229,7 +225,7 @@ public class Harvester implements Serializable {
    *     {@link Object }
    *
    */
-  public Object getFilter() {
+  public String getFilter() {
     return filter;
   }
 
@@ -241,7 +237,7 @@ public class Harvester implements Serializable {
    *     {@link Object }
    *
    */
-  public void setFilter(Object value) {
+  public void setFilter(String value) {
     this.filter = value;
   }
 

--- a/harvesters/harvester-common/src/main/java/org/daobs/harvester/config/package-info.java
+++ b/harvesters/harvester-common/src/main/java/org/daobs/harvester/config/package-info.java
@@ -1,0 +1,12 @@
+@XmlSchema(
+  namespace = "http://daobs.org",
+  xmlns = {
+    @XmlNs(prefix = "daobs", namespaceURI = "http://daobs.org")
+  },
+  elementFormDefault = XmlNsForm.QUALIFIED
+)
+package org.daobs.harvester.config;
+
+import javax.xml.bind.annotation.XmlNs;
+import javax.xml.bind.annotation.XmlNsForm;
+import javax.xml.bind.annotation.XmlSchema;

--- a/harvesters/harvester-common/src/main/resources/org/daobs/harvester/config/jaxb.properties
+++ b/harvesters/harvester-common/src/main/resources/org/daobs/harvester/config/jaxb.properties
@@ -1,0 +1,1 @@
+javax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory

--- a/harvesters/harvester-common/src/test/java/org/daobs/harvester/config/HarvesterJaxbTest.java
+++ b/harvesters/harvester-common/src/test/java/org/daobs/harvester/config/HarvesterJaxbTest.java
@@ -1,0 +1,41 @@
+package org.daobs.harvester.config;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.StringWriter;
+import java.util.UUID;
+
+/**
+ * Created by juanl on 23/03/2017.
+ */
+public class HarvesterJaxbTest {
+
+  @Test
+  public void testHarvesterSerialization() throws JAXBException {
+    String filterString = "<test>test-filter</test>";
+    Harvesters harvesters = new Harvesters();
+    Harvester harvester = new Harvester();
+    harvester.setFilter(filterString);
+    harvester.setFolder("folder");
+    harvester.setName("harvester name");
+    harvester.setNbOfRecordsPerPage(10);
+    harvester.setPointOfTruthURLPattern("http://example.com/register/{{uuid}}");
+    harvester.setServiceMetadata("http://example.com/record");
+    harvester.setTerritory("ES");
+    harvester.setUuid(UUID.randomUUID().toString());
+    harvester.setUrl("http://example.com/service/csw");
+    harvesters.getHarvester().add(harvester);
+
+    JAXBContext jaxbContext = JAXBContext.newInstance(Harvesters.class);
+    Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+
+    StringWriter sw = new StringWriter();
+    jaxbMarshaller.marshal(harvesters, sw);
+
+    assertTrue(sw.toString().contains("<daobs:filter>" + filterString + "</daobs:filter>"));
+  }
+}

--- a/web/src/main/java/org/daobs/controller/exception/DaobsExceptionHandler.java
+++ b/web/src/main/java/org/daobs/controller/exception/DaobsExceptionHandler.java
@@ -21,6 +21,7 @@
 
 package org.daobs.controller.exception;
 
+import org.apache.commons.lang.StringEscapeUtils;
 import org.daobs.controller.binding.ErrorResource;
 import org.daobs.controller.binding.FieldErrorResource;
 import org.springframework.http.HttpHeaders;
@@ -50,7 +51,8 @@ public class DaobsExceptionHandler extends ResponseEntityExceptionHandler {
       // fieldErrorResource.setResource(fieldError.getObjectName());
       // fieldErrorResource.setField(fieldError.getField());
       // fieldErrorResource.setCode(fieldError.getCode());
-      fieldErrorResource.setMessage(fieldError);
+      fieldErrorResource.setMessage(StringEscapeUtils.escapeJavaScript(
+          StringEscapeUtils.escapeHtml(fieldError)));
       fieldErrorResources.add(fieldErrorResource);
     }
 

--- a/web/src/main/java/org/daobs/harvester/repository/HarvesterConfigRepository.java
+++ b/web/src/main/java/org/daobs/harvester/repository/HarvesterConfigRepository.java
@@ -21,6 +21,8 @@
 
 package org.daobs.harvester.repository;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.daobs.controller.exception.InvalidHarvesterException;
 import org.daobs.harvester.config.Harvester;
 import org.daobs.harvester.config.Harvesters;
@@ -28,19 +30,22 @@ import org.daobs.utility.UuidFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ResourceLoader;
+import org.xml.sax.InputSource;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.StringReader;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 
 /**
  * A really simple harvester repository based on the
@@ -80,6 +85,8 @@ public class HarvesterConfigRepository implements InitializingBean {
       }
     } catch (JAXBException exception) {
       throw new RuntimeException(exception);
+    } catch (IOException exception) {
+      throw new RuntimeException(exception);
     }
     return true;
   }
@@ -94,7 +101,7 @@ public class HarvesterConfigRepository implements InitializingBean {
 
   /**
    * Add or update an harvester configuration.
-     */
+   */
   public synchronized Harvester addOrUpdate(Harvester harvester) throws Exception {
     if (harvester != null) {
       String uuid = harvester.getUuid();
@@ -123,7 +130,8 @@ public class HarvesterConfigRepository implements InitializingBean {
   }
 
   /**
-   *  Check harvester configuration.
+   * Check harvester configuration.
+   *
    * @return Return list of errors
    */
   private List<String> isValid(Harvester harvester) {
@@ -144,28 +152,28 @@ public class HarvesterConfigRepository implements InitializingBean {
       listOfErrors.add(String.format("Harvester with UUID '%s' does not have territory.",
           harvester.getUuid()));
     }
-    // String filter = (String) harvester.getFilter();
-    // if (filter != null) {
-    //     DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
-    //     domFactory.setNamespaceAware(true);
-    //     try {
-    //         DocumentBuilder builder = domFactory.newDocumentBuilder();
-    //         builder.parse(new InputSource(
-    //                         new StringReader(filter)));
-    //     } catch (Exception exception) {
-    //         listOfErrors.add(String.format("Harvester with UUID '%s' does not have " +
-    //                         "a valid filter '%s'. Error is: %s.",
-    //                 harvester.getUuid(), filter, e.getMessage()));
-    //     }
-    // }
+    String filter = harvester.getFilter();
+    if (StringUtils.isNotBlank(filter)) {
+      DocumentBuilderFactory domFactory = DocumentBuilderFactory.newInstance();
+      domFactory.setNamespaceAware(true);
+      try {
+        DocumentBuilder builder = domFactory.newDocumentBuilder();
+        builder.parse(new InputSource(
+            new StringReader(filter)));
+      } catch (Exception exception) {
+        listOfErrors.add(String.format("Harvester with UUID '%s' does not have "
+            + "a valid filter '%s'. Error is: %s.",
+            harvester.getUuid(), filter, exception.getMessage()));
+      }
+    }
     return listOfErrors;
   }
 
   /**
    * Set defaults for an incomplete harvester.
    * <ul>
-   *     <li>territory is set to UUID</li>
-   *     <li>folder is set to territory</li>
+   * <li>territory is set to UUID</li>
+   * <li>folder is set to territory</li>
    * </ul>
    */
   private void accomodate(Harvester harvester) {
@@ -180,7 +188,7 @@ public class HarvesterConfigRepository implements InitializingBean {
 
   /**
    * Remove harvester.
-     */
+   */
   public synchronized boolean remove(String harvesterUuid) throws Exception {
     Harvester harvester = findByUuid(harvesterUuid);
     if (harvester == null) {
@@ -198,21 +206,37 @@ public class HarvesterConfigRepository implements InitializingBean {
   /**
    * Save the harvester configuration file.
    */
-  private synchronized void commit() {
+  private synchronized void commit() throws IOException {
     JAXBContext jaxbContext = null;
     try {
+      // create config backup
+      FileUtils.copyFile(new File(configurationFilepath), new File(configurationFilepath + ".bak"));
       jaxbContext = JAXBContext.newInstance(Harvesters.class);
       Marshaller marshaller = jaxbContext.createMarshaller();
       marshaller.marshal(harvesters, new File(configurationFilepath));
     } catch (JAXBException exception) {
       exception.printStackTrace();
+      // restore backup
+      try {
+        FileUtils.copyFile(new File(configurationFilepath + ".bak"),
+            new File(configurationFilepath));
+      } catch (IOException oops) {
+        // Error restoring config backup
+        oops.printStackTrace();
+      }
+
+    } catch (IOException exception) {
+      exception.printStackTrace();
+      throw exception;
+    } finally {
+      FileUtils.deleteQuietly(new File(configurationFilepath + ".bak"));
+      reload();
     }
-    reload();
   }
 
   /**
    * Start a harvester.
-     */
+   */
   public synchronized boolean start(String harvesterUuid) throws Exception {
     Harvester harvester = findByUuid(harvesterUuid);
     if (harvester == null) {
@@ -256,8 +280,8 @@ public class HarvesterConfigRepository implements InitializingBean {
     SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateFormat);
     String dataStampString = simpleDateFormat.format(dataStamp);
     return harvestingTasksFolder + File.separator
-        + harvesterUuid + "_"
-        + dataStampString + ".xml";
+      + harvesterUuid + "_"
+      + dataStampString + ".xml";
   }
 
   /**


### PR DESCRIPTION
* Add eclipselink dependency due a bub in JAXB RI (the one included in the JRE)
* Add package-info.java with namespaces annotations for eclipse MOXy.
* Annotate the filter property as XmlAnyElement.
* Implement a DomHandler to manage the unmarshalling and marshalling of the element.
* Validate the user input for filter to avoid saving bad XML in the filter property.
* Escape the message returned to the user to avoid XSS attacks.
* Make a temporal copy of the config-harvester.xml file to avoid breaking it in case of exceptions.